### PR TITLE
Adicionando expectativas de mercado para taxa Selic (módulo bacen)

### DIFF
--- a/DadosAbertosBrasil/__init__.py
+++ b/DadosAbertosBrasil/__init__.py
@@ -45,5 +45,5 @@ from .uf import UF
 from ._utils.errors import *
 
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 __author__ = "Gustavo Furtado da Silva"

--- a/DadosAbertosBrasil/bacen.py
+++ b/DadosAbertosBrasil/bacen.py
@@ -489,6 +489,9 @@ def expectativas(
             "Selic",
             "Taxa de desocupação",
         )
+    elif expectativa in ("selic"):
+        expec = "ExpectativasMercadoSelic"
+        KPIS = ("Selic",)
     elif expectativa in ("trimestral", "trimestrais"):
         expec = "ExpectativasMercadoTrimestrais"
         KPIS = (
@@ -606,6 +609,7 @@ def expectativas(
         raise ValueError(
             """Valor inválido para o argumento `expectativa`. Insira um dos seguintes valores:
             - 'mensal' ou 'mensais';
+            - 'selic';
             - 'trimestral' ou 'trimestrais';
             - 'anual' ou 'anuais';
             - 'inflacao' ou 'inflacao12meses';

--- a/DadosAbertosBrasil/bacen.py
+++ b/DadosAbertosBrasil/bacen.py
@@ -352,6 +352,8 @@ def expectativas(
     expectativa : str
         'mensal' ou 'mensais'
             Expectativas de Mercado Mensal
+        'selic'
+            Expectativas de Mercado Selic
         'trimestral' ou 'trimestrais'
             Expectativas de Mercado Trimestral
         'anual' ou 'anuais'


### PR DESCRIPTION
O modo 'selic' foi adicionado à função `expectativas` do módulo `bacen`, conforme previsto na [API](https://olinda.bcb.gov.br/olinda/servico/Expectativas/versao/v1/swagger-ui3#/).

As expectativas futuras para a taxa SELIC são parametrizadas pelo campo 'Reuniao' (Rx/yyyy, com x de 1 a 8 para cada ano yyyy), simbolizando as reuniões periódicas do Comitê de Política Monetária (Copom) do Banco Central do Brasil.